### PR TITLE
Add codeowners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,6 @@
+@sigstore/codeowners-sigstore-ruby
+
+# The CODEOWNERS are managed via a GitHub team, but the current list is (in alphabetical order):
+
+# segiddins
+# woodruffw


### PR DESCRIPTION
Based off of sigstore-python

Signed-off-by: Samuel Giddins <segiddins@segiddins.me>
