### PR TITLE
Add default excludes to rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,8 +2,12 @@ AllCops:
   TargetRubyVersion: 3.0
   NewCops: enable
   Exclude:
-    - 'test/sigstore-conformance/**/*'
-    - 'test/tuf-conformance/**/*'
+    - "test/sigstore-conformance/**/*"
+    - "test/tuf-conformance/**/*"
+    - "node_modules/**/*"
+    - "tmp/**/*"
+    - "vendor/**/*"
+    - ".git/**/*"
 
 require:
   - rubocop-performance


### PR DESCRIPTION
Fixes rubocop on ci, where there are configs in vendor/

See https://github.com/rubocop/rubocop/issues/9832
