### PR TITLE
Update required_ruby_version to >= 3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     uses: ruby/actions/.github/workflows/ruby_versions.yml@master
     with:
       engine: all
-      min_version: 3.0
+      min_version: 3.1
 
   test:
     needs: ruby-versions
@@ -107,7 +107,7 @@ jobs:
     needs: ruby-versions
     runs-on: ${{ matrix.os }}
     name: TUF Ruby ${{ matrix.ruby }} / ${{ matrix.os }}
-    continue-on-error: "${{ startsWith(matrix.ruby, 'jruby') || (matrix.ruby == '3.0') }}"
+    continue-on-error: "${{ startsWith(matrix.ruby, 'jruby') }}"
     strategy:
       fail-fast: false
       matrix:
@@ -140,7 +140,7 @@ jobs:
           entrypoint: ${{ github.workspace }}/bin/tuf-conformance-entrypoint
           artifact-name: "test repositories ${{ matrix.ruby }} ${{ matrix.os }}"
         if: |
-          ${{ matrix.os }} == "ubuntu-latest" && ${{ matrix.ruby }} != "3.0"
+          ${{ matrix.os }} == "ubuntu-latest"
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.1
   NewCops: enable
   Exclude:
     - "test/sigstore-conformance/**/*"

--- a/bin/sigstore-ruby
+++ b/bin/sigstore-ruby
@@ -69,7 +69,7 @@ module Sigstore
       )
 
       verified = files_with_materials.all? do |file, input|
-        result = verifier.verify(input: input, policy: policy, offline: options[:offline])
+        result = verifier.verify(input:, policy:, offline: options[:offline])
 
         if result.verified?
           say "OK: #{file}"
@@ -98,7 +98,7 @@ module Sigstore
       contents = File.binread(file)
       bundle = Sigstore::Signer.new(
         jwt: options[:identity_token],
-        trusted_root: trusted_root
+        trusted_root:
       ).sign(contents)
 
       File.binwrite(options[:bundle], bundle.to_json) if options[:bundle]
@@ -204,10 +204,10 @@ module Sigstore
         if options[:signature] || options[:certificate]
           missing << sig unless File.exist?(sig)
           missing << cert unless File.exist?(cert)
-          input_map[file] = { cert: cert, sig: sig }
+          input_map[file] = { cert:, sig: }
         else
           missing << bundle unless File.exist?(bundle)
-          input_map[file] = { bundle: bundle }
+          input_map[file] = { bundle: }
         end
 
         raise Thor::InvocationError, "Missing files: #{missing.join(", ")}" if missing.any?

--- a/lib/sigstore/internal/key.rb
+++ b/lib/sigstore/internal/key.rb
@@ -40,13 +40,13 @@ module Sigstore
         case key_type
         when "ecdsa", "ecdsa-sha2-nistp256"
           pkey = OpenSSL::PKey::EC.new(key_bytes)
-          EDCSA.new(key_type, schema, pkey, key_id: key_id)
+          EDCSA.new(key_type, schema, pkey, key_id:)
         when "ed25519"
           pkey = ED25519.pkey_from_der([key_bytes].pack("H*"))
-          ED25519.new(key_type, schema, pkey, key_id: key_id)
+          ED25519.new(key_type, schema, pkey, key_id:)
         when "rsa"
           pkey = OpenSSL::PKey::RSA.new(key_bytes)
-          RSA.new(key_type, schema, pkey, key_id: key_id)
+          RSA.new(key_type, schema, pkey, key_id:)
         else
           raise ArgumentError, "Unsupported key type #{key_type}"
         end.tap do |key|

--- a/lib/sigstore/internal/x509.rb
+++ b/lib/sigstore/internal/x509.rb
@@ -384,11 +384,11 @@ module Sigstore
 
           if RUBY_VERSION >= "3.1"
             def unpack_at(string, format, offset:)
-              string.unpack(format, offset: offset)
+              string.unpack(format, offset:)
             end
 
             def unpack1_at(string, format, offset:)
-              string.unpack1(format, offset: offset)
+              string.unpack1(format, offset:)
             end
           else
             def unpack_at(string, format, offset:)
@@ -406,11 +406,11 @@ module Sigstore
             len = string.bytesize
             list = []
             while offset < len
-              sct_version, sct_log_id, sct_timestamp, sct_extensions_len = unpack_at(string, "Ca32Q>n", offset: offset)
+              sct_version, sct_log_id, sct_timestamp, sct_extensions_len = unpack_at(string, "Ca32Q>n", offset:)
               offset += 1 + 32 + 8 + 2
               raise Error::Unimplemented, "expect sct version to be 0, got #{sct_version}" unless sct_version.zero?
 
-              sct_extensions_bytes = unpack1_at(string, "a#{sct_extensions_len}", offset: offset).b
+              sct_extensions_bytes = unpack1_at(string, "a#{sct_extensions_len}", offset:).b
               offset += sct_extensions_len
 
               unless sct_extensions_len.zero?
@@ -419,9 +419,9 @@ module Sigstore
               end
 
               sct_signature_alg_hash, sct_signature_alg_sign, sct_signature_len = unpack_at(string, "CCn",
-                                                                                            offset: offset)
+                                                                                            offset:)
               offset += 1 + 1 + 2
-              sct_signature_bytes = unpack1_at(string, "a#{sct_signature_len}", offset: offset).b
+              sct_signature_bytes = unpack1_at(string, "a#{sct_signature_len}", offset:).b
               offset += sct_signature_len
               list << Timestamp.new(
                 version: sct_version,

--- a/lib/sigstore/rekor/checkpoint.rb
+++ b/lib/sigstore/rekor/checkpoint.rb
@@ -26,7 +26,7 @@ module Sigstore
           signed_note = SignedNote.from_text(text)
           checkpoint = LogCheckpoint.from_text(signed_note.note)
 
-          new(signed_note: signed_note, checkpoint: checkpoint)
+          new(signed_note:, checkpoint:)
         end
       end
 
@@ -57,10 +57,10 @@ module Sigstore
 
             sig_hash = signature_bytes.slice!(0, 4).unpack1("a4")
 
-            Signature.new(name: name, sig_hash: sig_hash, signature: signature_bytes)
+            Signature.new(name:, sig_hash:, signature: signature_bytes)
           end
 
-          new(note: note, signatures: signatures)
+          new(note:, signatures:)
         end
 
         def verify(rekor_keyring, key_id)
@@ -72,7 +72,7 @@ module Sigstore
                     "sig_hash hint #{signature.sig_hash.inspect} does not match key_id #{sig_hash.inspect}"
             end
 
-            rekor_keyring.verify(key_id: key_id.unpack1("H*"), signature: signature.signature, data: data)
+            rekor_keyring.verify(key_id: key_id.unpack1("H*"), signature: signature.signature, data:)
           end
         end
       end
@@ -91,7 +91,7 @@ module Sigstore
 
           raise Error::InvalidCheckpoint, "empty origin" if origin.empty?
 
-          new(origin: origin, log_size: log_size, log_hash: root_hash, other_content: lines)
+          new(origin:, log_size:, log_hash: root_hash, other_content: lines)
         end
       end
 

--- a/lib/sigstore/trusted_root.rb
+++ b/lib/sigstore/trusted_root.rb
@@ -92,10 +92,10 @@ module Sigstore
     end
 
     def ca_keys(certificate_authorities, allow_expired:)
-      return enum_for(__method__, certificate_authorities, allow_expired: allow_expired) unless block_given?
+      return enum_for(__method__, certificate_authorities, allow_expired:) unless block_given?
 
       certificate_authorities.each do |ca|
-        next unless timerange_valid?(ca.valid_for, allow_expired: allow_expired)
+        next unless timerange_valid?(ca.valid_for, allow_expired:)
 
         ca.cert_chain.certificates.each do |cert|
           yield cert.raw_bytes

--- a/lib/sigstore/tuf.rb
+++ b/lib/sigstore/tuf.rb
@@ -85,7 +85,7 @@ module Sigstore
                            URI.join("#{@repo_url.to_s.chomp("/")}/", "targets/"),
           target_dir: @targets_dir,
           fetcher: method(:fetch),
-          config: config
+          config:
         )
       end
 
@@ -93,7 +93,7 @@ module Sigstore
         app_name = "sigstore-ruby"
         app_author = "segiddins"
 
-        repo_base = encode_uri_component(url)
+        repo_base = URI.encode_uri_component(url)
         home = Dir.home
 
         data_home = ENV.fetch("XDG_DATA_HOME", File.join(home, ".local", "share"))
@@ -102,14 +102,6 @@ module Sigstore
         tuf_cache_dir = File.join(cache_home, app_name, app_author, "tuf")
 
         [File.join(tuf_data_dir, repo_base), File.join(tuf_cache_dir, repo_base)]
-      end
-
-      def encode_uri_component(str)
-        if URI.respond_to?(:encode_uri_component)
-          URI.encode_uri_component(str)
-        else
-          URI.encode_www_form_component(str).gsub("+", "%20")
-        end
       end
 
       def trusted_root_path

--- a/lib/sigstore/tuf/file.rb
+++ b/lib/sigstore/tuf/file.rb
@@ -88,7 +88,7 @@ module Sigstore::TUF
         length = meta_dict.fetch("length", nil)
         hashes = meta_dict.fetch("hashes", nil)
 
-        new(version: version, length: length, hashes: hashes,
+        new(version:, length:, hashes:,
             unrecognized_fields: meta_dict.slice(*(meta_dict.keys - %w[version length hashes])))
       end
     end

--- a/lib/sigstore/tuf/keys.rb
+++ b/lib/sigstore/tuf/keys.rb
@@ -25,7 +25,7 @@ module Sigstore::TUF
         keyval = key_data.fetch("keyval")
         public_key_data = keyval.fetch("public")
 
-        key = Sigstore::Internal::Key.read(key_type, scheme, public_key_data, key_id: key_id)
+        key = Sigstore::Internal::Key.read(key_type, scheme, public_key_data, key_id:)
 
         [key_id, key]
       end
@@ -35,8 +35,8 @@ module Sigstore::TUF
       @keys.fetch(key_id)
     end
 
-    def each(&block)
-      @keys.each(&block)
+    def each(&)
+      @keys.each(&)
     end
   end
 end

--- a/lib/sigstore/tuf/roles.rb
+++ b/lib/sigstore/tuf/roles.rb
@@ -37,8 +37,8 @@ module Sigstore::TUF
         end
     end
 
-    def each(&block)
-      @roles.each(&block)
+    def each(&)
+      @roles.each(&)
     end
 
     def verify_delegate(type, bytes, signatures)

--- a/lib/sigstore/verifier.rb
+++ b/lib/sigstore/verifier.rb
@@ -47,11 +47,11 @@ module Sigstore
     end
 
     def self.production(trust_root: TrustedRoot.production)
-      for_trust_root(trust_root: trust_root)
+      for_trust_root(trust_root:)
     end
 
     def self.staging(trust_root: TrustedRoot.staging)
-      for_trust_root(trust_root: trust_root)
+      for_trust_root(trust_root:)
     end
 
     def verify(input:, policy:, offline:)
@@ -79,7 +79,7 @@ module Sigstore
       begin
         # TODO: should this instead be an input to the verify method?
         # See https://docs.google.com/document/d/1kbhK2qyPPk8SLavHzYSDM8-Ueul9_oxIMVFuWMWKz0E/edit?disco=AAABQVV-gT0
-        entry = find_rekor_entry(bundle, input.hashed_input, offline: offline)
+        entry = find_rekor_entry(bundle, input.hashed_input, offline:)
       rescue Sigstore::Error::MissingRekorEntry
         return VerificationFailure.new("Rekor entry not found")
       else
@@ -93,7 +93,7 @@ module Sigstore
         end
       end
 
-      Internal::SET.verify_set(keyring: @rekor_keyring, entry: entry) if entry.inclusion_promise
+      Internal::SET.verify_set(keyring: @rekor_keyring, entry:) if entry.inclusion_promise
 
       timestamps << Time.at(entry.integrated_time).utc
 

--- a/sigstore.gemspec
+++ b/sigstore.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.summary = "A pure-ruby implementation of sigstore signature verification"
   spec.homepage = "https://github.com/sigstore/sigstore-ruby"
   spec.license = "Apache-2.0"
-  spec.required_ruby_version = ">= 3.0.0"
+  spec.required_ruby_version = ">= 3.1.0"
 
   spec.metadata["allowed_push_host"] = "https://rubygems.org"
 

--- a/test/sigstore/internal/tuf_test.rb
+++ b/test/sigstore/internal/tuf_test.rb
@@ -52,7 +52,7 @@ class Sigstore::TUFTest < Test::Unit::TestCase
     targets_dir = File.join(Dir.home, "custom-targets")
     metadata_dir = File.join(Dir.home, "custom-metadata")
     updater = Sigstore::TUF::TrustUpdater.new("https://tuf-repo-cdn.sigstore.dev", true,
-                                              metadata_dir: metadata_dir, targets_dir: targets_dir)
+                                              metadata_dir:, targets_dir:)
     assert_equal(File.join(targets_dir, "trusted_root.json"), updater.trusted_root_path)
   end
 end


### PR DESCRIPTION
Ruby 3.0 is now EOL and bundler/rubygems have dropped support

Signed-off-by: Samuel Giddins <segiddins@segiddins.me>
