### PR TITLE
Drastically speed up test running on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,16 +12,15 @@ permissions: {}
 
 jobs:
   ruby-versions:
-    uses: ruby/actions/.github/workflows/ruby_versions.yml@master
+    uses: ruby/actions/.github/workflows/ruby_versions.yml@3fbf038d6f0d8043b914f923764c61bc2a114a77
     with:
-      engine: all
+      engine: cruby-truffleruby
       min_version: 3.1
 
   test:
     needs: ruby-versions
     runs-on: ${{ matrix.os }}
     name: Test Ruby ${{ matrix.ruby }} / ${{ matrix.os }}
-    continue-on-error: ${{ startsWith(matrix.ruby, 'jruby') }}
     strategy:
       fail-fast: false
       matrix:
@@ -58,7 +57,6 @@ jobs:
   sigstore-conformance:
     needs: ruby-versions
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ startsWith(matrix.ruby, 'jruby') }}
     name: Sigstore Ruby ${{ matrix.ruby }} / ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -107,7 +105,6 @@ jobs:
     needs: ruby-versions
     runs-on: ${{ matrix.os }}
     name: TUF Ruby ${{ matrix.ruby }} / ${{ matrix.os }}
-    continue-on-error: "${{ startsWith(matrix.ruby, 'jruby') }}"
     strategy:
       fail-fast: false
       matrix:

--- a/.simplecov
+++ b/.simplecov
@@ -2,6 +2,8 @@
 
 SimpleCov.root(__dir__)
 
-SimpleCov.start do
-  enable_coverage :branch unless RUBY_ENGINE == "truffleruby"
+if ENV["COVERAGE"]
+  SimpleCov.start do
+    enable_coverage :branch unless RUBY_ENGINE == "truffleruby"
+  end
 end

--- a/bin/conformance-entrypoint
+++ b/bin/conformance-entrypoint
@@ -24,5 +24,5 @@ ENV.update(
 )
 
 load File.expand_path("sigstore-ruby", __dir__)
-ARGV.delete("--verify-digest")
-Sigstore::CLI.start(ARGV)
+
+Sigstore::CLI.start(ARGV << "--no-update-trusted-root")

--- a/bin/sigstore-ruby
+++ b/bin/sigstore-ruby
@@ -55,6 +55,7 @@ module Sigstore
     option :offline, type: :boolean, desc: "Do not fetch the latest timestamp from the Rekor server"
     option :bundle, type: :string, desc: "Path to the signed bundle"
     option :trusted_root, type: :string, desc: "Path to the trusted root"
+    option :update_trusted_root, type: :boolean, desc: "Update the trusted root", default: true
     exclusive :bundle, :signature
     exclusive :bundle, :certificate
     def verify(*files)
@@ -90,6 +91,8 @@ module Sigstore
     option :bundle, type: :string, desc: "Path to write the signed bundle to"
     option :signature, type: :string, desc: "Path to write the signature to"
     option :certificate, type: :string, desc: "Path to the public certificate"
+    option :trusted_root, type: :string, desc: "Path to the trusted root"
+    option :update_trusted_root, type: :boolean, desc: "Update the trusted root", default: true
     def sign(file)
       require "sigstore/signer"
 
@@ -166,7 +169,11 @@ module Sigstore
     def trusted_root
       return Sigstore::TrustedRoot.from_file(options[:trusted_root]) if options[:trusted_root]
 
-      options[:staging] ? Sigstore::TrustedRoot.staging : Sigstore::TrustedRoot.production
+      if options[:staging]
+        Sigstore::TrustedRoot.staging(offline: !options[:update_trusted_root])
+      else
+        Sigstore::TrustedRoot.production(offline: !options[:update_trusted_root])
+      end
     end
 
     def collect_verification_state(files)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,7 +4,7 @@ require "simplecov"
 SimpleCov.configure do
   add_filter "test/"
 end
-SimpleCov.start
+SimpleCov.start if ENV["COVERAGE"]
 
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "sigstore"


### PR DESCRIPTION
Takes sigstore conformance tests from 5+ minutes locally to 2

Removes jruby since those tests are hopelessly broken and we are not currently making progress on them

Signed-off-by: Samuel Giddins <segiddins@segiddins.me>
