### PR TITLE
Parse out the id token value in smoketest

### DIFF
--- a/bin/smoketest
+++ b/bin/smoketest
@@ -4,6 +4,7 @@
 require "fileutils"
 require "rake"
 require "net/http"
+require "json"
 
 include FileUtils # rubocop:disable Style/MixinUsage
 
@@ -31,7 +32,7 @@ id_token ||= Net::HTTP.get_response(
   URI(ENV.fetch("ACTIONS_ID_TOKEN_REQUEST_URL") + "&audience=#{URI.encode_uri_component("sigstore")}"),
   { "Authorization" => "bearer #{ENV.fetch("ACTIONS_ID_TOKEN_REQUEST_TOKEN")}" },
   &:value
-).body
+).body.then { JSON.parse(_1).fetch("value") }
 
 sh(env, File.expand_path("sigstore-ruby", __dir__),
    "sign", dist, "--identity-token=#{id_token}",

--- a/lib/sigstore/signer.rb
+++ b/lib/sigstore/signer.rb
@@ -114,7 +114,7 @@ module Sigstore
 
       unless resp.code == "200"
         raise Error::Signing,
-              "#{resp.code} #{resp.message}\n\n#{Internal::Util.base64_encode JSON.dump(csr)}\n\n#{resp.body}"
+              "#{resp.code} #{resp.message}\n\n#{resp.body}"
       end
 
       resp_body = JSON.parse(resp.body)


### PR DESCRIPTION
Stop leaking csr when generating cert fails, it was leftover debugging code

Signed-off-by: Samuel Giddins <segiddins@segiddins.me>
