### PR TITLE
Make OIDC audience configurable

### DIFF
--- a/cli/lib/sigstore/cli.rb
+++ b/cli/lib/sigstore/cli.rb
@@ -80,6 +80,7 @@ module Sigstore
     desc "sign ARTIFACT", "Sign a file"
     option :staging, type: :boolean, desc: "Use the staging trusted root"
     option :identity_token, type: :string, desc: "Identity token to use for signing"
+    option :oidc_audience, type: :string, desc: "Expected audience for the OIDC token", default: "sigstore"
     option :bundle, type: :string, desc: "Path to write the signed bundle to"
     option :signature, type: :string, desc: "Path to write the signature to"
     option :certificate, type: :string, desc: "Path to the public certificate"
@@ -95,7 +96,8 @@ module Sigstore
       contents = File.binread(file)
       bundle = Sigstore::Signer.new(
         jwt: options[:identity_token],
-        trusted_root:
+        trusted_root:,
+        oidc_audience: options[:oidc_audience]
       ).sign(contents)
 
       File.binwrite(options[:bundle], bundle.to_json) if options[:bundle]

--- a/lib/sigstore/oidc.rb
+++ b/lib/sigstore/oidc.rb
@@ -30,10 +30,10 @@ module Sigstore
     class IdentityToken
       attr_reader :raw_token, :identity
 
-      def initialize(raw_token)
+      def initialize(raw_token, audience: DEFAULT_AUDIENCE)
         @raw_token = raw_token
 
-        @unverified_claims = self.class.decode_jwt(raw_token)
+        @unverified_claims = self.class.decode_jwt(raw_token, audience: audience)
         @iss = @unverified_claims["iss"]
         @nbf = @unverified_claims["nbf"]
         @exp = @unverified_claims["exp"]
@@ -58,12 +58,11 @@ module Sigstore
         @iss
       end
 
-      def self.decode_jwt(raw_token)
+      def self.decode_jwt(raw_token, audience: DEFAULT_AUDIENCE)
         # These claims are required by OpenID Connect, so
         # we can strongly enforce their presence.
         # See: https://openid.net/specs/openid-connect-basic-1_0.html#IDToken
         required = %w[aud sub iat exp iss]
-        audience = DEFAULT_AUDIENCE
         leeway = 5
 
         _header, payload, _signature =

--- a/lib/sigstore/signer.rb
+++ b/lib/sigstore/signer.rb
@@ -26,8 +26,8 @@ module Sigstore
   class Signer
     include Loggable
 
-    def initialize(jwt:, trusted_root:)
-      @identity_token = OIDC::IdentityToken.new(jwt)
+    def initialize(jwt:, trusted_root:, oidc_audience: OIDC::DEFAULT_AUDIENCE)
+      @identity_token = OIDC::IdentityToken.new(jwt, audience: oidc_audience)
       @trusted_root = trusted_root
 
       @verifier = Verifier.for_trust_root(trust_root: @trusted_root)


### PR DESCRIPTION
Add support for custom OIDC token audiences to handle cases where identity providers use different audience values than the default "sigstore".

## Changes
- Add optional `audience` parameter to `IdentityToken.initialize`
- Add optional `oidc_audience` parameter to `Signer.initialize`
- Add `--oidc-audience` CLI option (defaults to "sigstore")

## Rationale
This aligns with sigstore-python's approach (sigstore/sigstore-python#1402) and provides flexibility for different OIDC providers while maintaining backward compatibility with the default "sigstore" audience.

Fixes the test failures caused by tokens with non-standard audience values.