### PR TITLE
Handle missing nonce on RFC 3161 timestamp

### DIFF
--- a/lib/sigstore/verifier.rb
+++ b/lib/sigstore/verifier.rb
@@ -386,7 +386,7 @@ module Sigstore
         req.message_imprint = resp.token_info.message_imprint
         req.algorithm = resp.token_info.algorithm
         req.policy_id = resp.token_info.policy_id
-        req.nonce = resp.token_info.nonce
+        req.nonce = resp.token_info.nonce unless resp.token_info.nonce.nil?
         req.version = resp.token_info.version
 
         # TODO: verify the hashed message in the message imprint

--- a/test/sigstore/verifier_test.rb
+++ b/test/sigstore/verifier_test.rb
@@ -156,4 +156,18 @@ class Sigstore::VerifierTest < Test::Unit::TestCase
       ].map!(&:b).join, data, "precert_bytes_len=#{precert_bytes_len}"
     end
   end
+
+  def test_extract_timestamp_from_verification_data_without_rfc_3161_nonce
+    verifier = Sigstore::Verifier.production
+
+    timestamp = Sigstore::Common::V1::RFC3161SignedTimestamp.new
+    timestamp.signed_timestamp = Base64.decode64(<<~BASE64)
+      MIICyTADAgEAMIICwAYJKoZIhvcNAQcCoIICsTCCAq0CAQMxDTALBglghkgBZQMEAgEwgbgGCyqGSIb3DQEJEAEEoIGoBIGlMIGiAgEBBgkrBgEEAYO/MAIwMTANBglghkgBZQMEAgEFAAQgTKqbxePJ+CMrGBHbCJdNl3teazpMNV33uU8kNYjy92ICFQDHJBQaFf/zj3wr29ngtGyA4ySWVhgPMjAyNjAzMjgwMDA5NTlaMAMCAQGgMqQwMC4xFTATBgNVBAoTDHNpZ3N0b3JlLmRldjEVMBMGA1UEAxMMc2lnc3RvcmUtdHNhoAAxggHaMIIB1gIBATBRMDkxFTATBgNVBAoTDHNpZ3N0b3JlLmRldjEgMB4GA1UEAxMXc2lnc3RvcmUtdHNhLXNlbGZzaWduZWQCFDoTVC8MkGHuvMFDL8uKjosqI4sMMAsGCWCGSAFlAwQCAaCB/DAaBgkqhkiG9w0BCQMxDQYLKoZIhvcNAQkQAQQwHAYJKoZIhvcNAQkFMQ8XDTI2MDMyODAwMDk1OVowLwYJKoZIhvcNAQkEMSIEIHd3A50sJJyWXPJleY3p7eklwNNBmjXWyHwpZT31UrMbMIGOBgsqhkiG9w0BCRACLzF/MH0wezB5BCCF+Se8B6tiysO0Q1bBDvyBssaIP9p6uebYcNnROs0FtzBVMD2kOzA5MRUwEwYDVQQKEwxzaWdzdG9yZS5kZXYxIDAeBgNVBAMTF3NpZ3N0b3JlLXRzYS1zZWxmc2lnbmVkAhQ6E1QvDJBh7rzBQy/Lio6LKiOLDDAKBggqhkjOPQQDAgRmMGQCMHpk9rghxIn1pe2SglUQbCIWgbQKvPOoNzUQrEeAlH3jhFvZDV9PVGQ58uBt5qnszgIwL4seQSRmpcehSGi/yN4mearqVqhTewXDzdvP579e/rM9b93w1rAA2q1UYfCM3Bq2
+    BASE64
+
+    data = Sigstore::Bundle::V1::TimestampVerificationData.new
+    data.rfc3161_timestamps = [timestamp]
+
+    assert_equal verifier.send(:extract_timestamp_from_verification_data, data), [Time.parse("2026-03-28T00:09:59Z")]
+  end
 end


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Fixes #304

RFC 3161 timestamps have an optional nonce, but verification fails if this is absent.

```
Can't convert nil into Integer

    req.nonce = resp.token_info.nonce
                ^^^^^^^^^^^^^^^^^^^^^
    ~/.gem/ruby/4.0.2/gems/sigstore-0.2.3/lib/sigstore/verifier.rb:389:in 'OpenSSL::Timestamp::Request#nonce='
    ~/.gem/ruby/4.0.2/gems/sigstore-0.2.3/lib/sigstore/verifier.rb:389:in 'block in Sigstore::Verifier#extract_timestamp_from_verification_data'
```

This PR prevents the error by guarding the assignment of `nonce` in the `OpenSSL::Timestamp::Request` with a check that it isn't `nil`.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
Fix verification of RFC 3161 timestamps without nonces.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
No