### PR TITLE
Verify Rekor-provided time with SET before use

### DIFF
--- a/lib/sigstore/verifier.rb
+++ b/lib/sigstore/verifier.rb
@@ -93,9 +93,12 @@ module Sigstore
         end
       end
 
-      Internal::SET.verify_set(keyring: @rekor_keyring, entry:) if entry.inclusion_promise
+      if entry.inclusion_promise
+        Internal::SET.verify_set(keyring: @rekor_keyring, entry:)
+        timestamps << Time.at(entry.integrated_time).utc
+      end
 
-      timestamps << Time.at(entry.integrated_time).utc
+      return VerificationFailure.new("No verified timestamp") if timestamps.empty?
 
       # 3)
       # The Verifier MUST perform certification path validation (RFC 5280 §6) of the certificate chain with the


### PR DESCRIPTION
sigstore-ruby accepted a Sigstore bundle whose Rekor v1 transparency log entry contains an inclusion proof and checkpoint, but did not contain a Signed Entry Timestamp (SET). The verifier then used the associated integratedTime as signing-time evidence even though that timestamp was not signed by Rekor.